### PR TITLE
feat: autogenerated README, help, manpage

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -1,4 +1,20 @@
-var argv = require('minimist')(process.argv.slice(2), {
+var meow = require('meow');
+var usage = "## Options\n\n    --type=<elapsed-line|elapsed-total|absolute>        [default: elapsed-line]\n    -t <elapsed-line|elapsed-total|absolute>\n\n      Type of timestamp to display.\n        elapsed-line: Number of seconds that displayed line was the last line.\n        elapsed-total: Number of seconds since the start of the process.\n        absolute: An absolute timestamp in UTC.\n\n    --format=\"format\"                                   [default: \"H:i:s.u O\"]\n    -f \"format\"\n\n      Format the absolute timestamp, using PHP date format strings. If the type\n      is elapsed-line or elapsed-total, this option is ignored.\n\n    --ignore-blank                                      [default: false]\n    --quiet\n    -q\n    -i\n\n      Do not prepend a timestamp to blank lines; just pass them through. When\n      this option is active, blank lines will not trigger an update of elapsed\n      time. Therefore, if a lot of blank lines appear, the prior timestamp will\n      display the total time between that line and the next non-blank line\n      (if the type is elapsed-time was selected).\n\n\t--real-time=<number|false>                          [default: 500]\n\t-r                                                  [non-tty default: false]\n\n\t  Time increment to use when updating timestamp for the current line, in\n\t  milliseconds. Pass `false` to this option to disable realtime entirely,\n\t  if you need an extra performance boost or you find it distracting. When\n\t  realtime is disabled, the log will always appear one line \"behind\" the\n\t  original piped output, since it can't display the line until it's\n\t  finished timing it.\n\n    --high=seconds\n    -h seconds\n\n      High threshold. If the elapsed time for a line is equal to or higher than\n      this value in seconds, then the timestamp will be colored bright red.\n      This works for all timestamp types, including elapsed-total and absolute,\n      where the elapsed line time is not actually displayed.\n\n    --medium=seconds\n    -m seconds\n\n      Medium threshold. Works just like the high threshold described above, but\n      colors the timestamp bright yellow instead. Can be used in conjunction\n      with a high threshold for three levels.\n\n### Notes\n - If a `high` and/or a `medium` threshold are specified, then all timestamps not\nmeeting that threshold will be colored bright green.\n - If you pipe the output of `gnomon` into another command or a file (that is,\n not a tty) then the `real-time` option will be disabled by default and each line\n will appear only after it has been timed. You can force realtime by sending a\n `--real-time=<ms>` argument explicitly, but the ANSI codes would probably\n interfere with whatever you were trying to do. The sane default is to omit fancy\n stuff, like colors and escape sequences, when logging text directly to a file.\n\n\n## License\n\ngnomon uses the MIT license.\n\n";
+var intro = [
+  '',
+  '## Usage',
+  '',
+  'Use UNIX (or DOS) pipes to pipe the stdout of any command through gnomon.',
+  '',
+  '  npm test | gnomon',
+  '',
+  'Use command-line options to adjust gnomon\'s behavior.',
+  '',
+  '  any-command-to-be-timed | gnomon --type=elapsed-total --high=8.0',
+  '',
+  ''
+];
+var cli = meow(intro.join('\n') + usage, {
   string: ['format','type'],
   boolean: ['ignore-blank', 'ignoreBlank'],
   alias: {
@@ -10,14 +26,20 @@ var argv = require('minimist')(process.argv.slice(2), {
     'realTime': ['real-time', 'r']
   }
 });
-if (argv.realTime === 'false') argv.realTime = false;
-if (process.stdout.isTTY && !argv.hasOwnProperty('realTime')) {
-  argv.realTime = true;
+if (process.stdin.isTTY) {
+  console.error('Error: You must pipe another command\'s output to gnomon with |.');
+  console.log(intro.join('\n  '));
+  process.exit(1);
 }
-if (argv.realTime && typeof argv.realTime !== 'number') argv.realTime = 500;
+var flags = cli.flags;
+if (flags.realTime === 'false') flags.realTime = false;
+if (process.stdout.isTTY && !flags.hasOwnProperty('realTime')) {
+  flags.realTime = true;
+}
+if (flags.realTime && typeof flags.realTime !== 'number') flags.realTime = 500;
 var split = require('split');
 var gnomon = require('./');
 process.stdin.pipe(split())
-.pipe(gnomon(argv))
+.pipe(gnomon(flags))
 .pipe(process.stdout);
 process.stdout.on('error', process.exit);

--- a/doc/gnomon.1
+++ b/doc/gnomon.1
@@ -1,0 +1,115 @@
+.TH "GNOMON" "" "November 2016" "" ""
+.SH "NAME"
+\fBgnomon\fR
+.P
+A command line utility, a bit like
+moreutils's \fBts\fR \fIhttps://joeyh\.name/code/moreutils/\fR, to prepend timestamp
+information to the standard output of another command\. Useful for long\-running
+processes where you'd like a historical record of what's taking so long\.
+.SH Example
+.P
+basic \fIhttps://cloud\.githubusercontent\.com/assets/1643758/13685018/17b4f76c\-e6d4\-11e5\-8838\-40fa52346ae8\.gif\fR
+.P
+Piping anything to \fBgnomon\fP will prepend a timestamp to each line, indicating 
+how long that line was the last line in the buffer\-\-that is, how long it took
+the next line to appear\. By default, \fBgnomon\fP will display the seconds elapsed
+between each line, but that is configurable\.
+.P
+You can display total time elapsed since the process began:
+total \fIhttps://cloud\.githubusercontent\.com/assets/1643758/13685020/199b78b2\-e6d4\-11e5\-9083\-05de6c52cc60\.gif\fR
+.P
+You can display an absolute timestamp:
+absolute \fIhttps://cloud\.githubusercontent\.com/assets/1643758/13685022/1ab3a5bc\-e6d4\-11e5\-9ccf\-3a5c68f9ea0c\.gif\fR
+.P
+You can also use the \fB\-\-high\fP and/or \fB\-\-medium\fP options to specify a length
+threshold in seconds, over which \fBgnomon\fP will highlight the timestamp in red
+or yellow\. And you can do a few other things, too\.
+.P
+fancy \fIhttps://cloud\.githubusercontent\.com/assets/1643758/13685025/1bbf6ad6\-e6d4\-11e5\-8806\-e90a6e852bf7\.gif\fR
+.P
+If the realtime timestamp updating is distracting or incompatible with your
+terminal, it can be disabled:
+.P
+norealtime \fIhttps://cloud\.githubusercontent\.com/assets/1643758/13685027/1cfd823e\-e6d4\-11e5\-9f90\-c047d67a35e0\.gif\fR
+.SH Options
+.P
+.RS 2
+.nf
+\-\-type=<elapsed\-line|elapsed\-total|absolute>        [default: elapsed\-line]
+\-t <elapsed\-line|elapsed\-total|absolute>
+
+  Type of timestamp to display\.
+    elapsed\-line: Number of seconds that displayed line was the last line\.
+    elapsed\-total: Number of seconds since the start of the process\.
+    absolute: An absolute timestamp in UTC\.
+
+\-\-format="format"                                   [default: "H:i:s\.u O"]
+\-f "format"
+
+  Format the absolute timestamp, using PHP date format strings\. If the type
+  is elapsed\-line or elapsed\-total, this option is ignored\.
+
+\-\-ignore\-blank                                      [default: false]
+\-\-quiet
+\-q
+\-i
+
+  Do not prepend a timestamp to blank lines; just pass them through\. When
+  this option is active, blank lines will not trigger an update of elapsed
+  time\. Therefore, if a lot of blank lines appear, the prior timestamp will
+  display the total time between that line and the next non\-blank line
+  (if the type is elapsed\-time was selected)\.
+
+\-\-real\-time=<number|false>                          [default: 500]
+\-r                                                  [non\-tty default: false]
+
+  Time increment to use when updating timestamp for the current line, in
+  milliseconds\. Pass `false` to this option to disable realtime entirely,
+  if you need an extra performance boost or you find it distracting\. When
+  realtime is disabled, the log will always appear one line "behind" the
+  original piped output, since it can't display the line until it's
+  finished timing it\.
+
+\-\-high=seconds
+\-h seconds
+
+  High threshold\. If the elapsed time for a line is equal to or higher than
+  this value in seconds, then the timestamp will be colored bright red\.
+  This works for all timestamp types, including elapsed\-total and absolute,
+  where the elapsed line time is not actually displayed\.
+
+\-\-medium=seconds
+\-m seconds
+
+  Medium threshold\. Works just like the high threshold described above, but
+  colors the timestamp bright yellow instead\. Can be used in conjunction
+  with a high threshold for three levels\.
+.fi
+.RE
+.SS Notes
+.RS 0
+.IP \(bu 2
+If a \fBhigh\fP and/or a \fBmedium\fP threshold are specified, then all timestamps not
+meeting that threshold will be colored bright green\.
+.IP \(bu 2
+If you pipe the output of \fBgnomon\fP into another command or a file (that is,
+not a tty) then the \fBreal\-time\fP option will be disabled by default and each line
+will appear only after it has been timed\. You can force realtime by sending a
+\fB\-\-real\-time=<ms>\fP argument explicitly, but the ANSI codes would probably
+interfere with whatever you were trying to do\. The sane default is to omit fancy
+stuff, like colors and escape sequences, when logging text directly to a file\.
+
+.RE
+.SH Installation
+.P
+with npm do:
+.P
+.RS 2
+.nf
+npm install \-g gnomon
+.fi
+.RE
+.SH License
+.P
+gnomon uses the MIT license\.
+

--- a/meta/cli-template.js
+++ b/meta/cli-template.js
@@ -1,0 +1,45 @@
+var meow = require('meow');
+var usage = __USAGE__;
+var intro = [
+  '',
+  '## Usage',
+  '',
+  'Use UNIX (or DOS) pipes to pipe the stdout of any command through gnomon.',
+  '',
+  '  npm test | gnomon',
+  '',
+  'Use command-line options to adjust gnomon\'s behavior.',
+  '',
+  '  any-command-to-be-timed | gnomon --type=elapsed-total --high=8.0',
+  '',
+  ''
+];
+var cli = meow(intro.join('\n') + usage, {
+  string: ['format','type'],
+  boolean: ['ignore-blank', 'ignoreBlank'],
+  alias: {
+    'format': 'f',
+    'type': 't',
+    'ignoreBlank': ['ignore-blank','quiet','q','i'],
+    'high': 'h',
+    'medium': 'm',
+    'realTime': ['real-time', 'r']
+  }
+});
+if (process.stdin.isTTY) {
+  console.error('Error: You must pipe another command\'s output to gnomon with |.');
+  console.log(intro.join('\n  '));
+  process.exit(1);
+}
+var flags = cli.flags;
+if (flags.realTime === 'false') flags.realTime = false;
+if (process.stdout.isTTY && !flags.hasOwnProperty('realTime')) {
+  flags.realTime = true;
+}
+if (flags.realTime && typeof flags.realTime !== 'number') flags.realTime = 500;
+var split = require('split');
+var gnomon = require('./');
+process.stdin.pipe(split())
+.pipe(gnomon(flags))
+.pipe(process.stdout);
+process.stdout.on('error', process.exit);

--- a/meta/installation.md
+++ b/meta/installation.md
@@ -1,0 +1,6 @@
+## Installation
+
+with npm do:
+```
+npm install -g gnomon
+```

--- a/meta/intro.md
+++ b/meta/intro.md
@@ -1,0 +1,32 @@
+# gnomon
+
+A command line utility, a bit like
+[moreutils's **ts**](https://joeyh.name/code/moreutils/), to prepend timestamp
+information to the standard output of another command. Useful for long-running
+processes where you'd like a historical record of what's taking so long.
+
+## Example
+
+![basic](https://cloud.githubusercontent.com/assets/1643758/13685018/17b4f76c-e6d4-11e5-8838-40fa52346ae8.gif)
+
+Piping anything to `gnomon` will prepend a timestamp to each line, indicating 
+how long that line was the last line in the buffer--that is, how long it took
+the next line to appear. By default, `gnomon` will display the seconds elapsed
+between each line, but that is configurable.
+
+You can display total time elapsed since the process began:
+![total](https://cloud.githubusercontent.com/assets/1643758/13685020/199b78b2-e6d4-11e5-9083-05de6c52cc60.gif)
+
+You can display an absolute timestamp:
+![absolute](https://cloud.githubusercontent.com/assets/1643758/13685022/1ab3a5bc-e6d4-11e5-9ccf-3a5c68f9ea0c.gif)
+
+You can also use the `--high` and/or `--medium` options to specify a length
+threshold in seconds, over which `gnomon` will highlight the timestamp in red
+or yellow. And you can do a few other things, too.
+
+![fancy](https://cloud.githubusercontent.com/assets/1643758/13685025/1bbf6ad6-e6d4-11e5-8806-e90a6e852bf7.gif)
+
+If the realtime timestamp updating is distracting or incompatible with your
+terminal, it can be disabled:
+
+![norealtime](https://cloud.githubusercontent.com/assets/1643758/13685027/1cfd823e-e6d4-11e5-9f90-c047d67a35e0.gif)

--- a/meta/license.md
+++ b/meta/license.md
@@ -1,0 +1,3 @@
+## License
+
+gnomon uses the MIT license.

--- a/meta/make-docs.js
+++ b/meta/make-docs.js
@@ -1,0 +1,29 @@
+var fs = require('fs');
+var path = require('path');
+var local = path.join.bind(path, __dirname);
+var up = path.resolve.bind(path, __dirname, '..');
+var docExt = '.md';
+console.log('Reading docs from ./docs...');
+var docs = fs.readdirSync(__dirname)
+  .filter(function(file) {
+    return fs.statSync(local(file)).isFile() &&
+      path.extname(file) === docExt;
+  })
+  .reduce(function(out, name) {
+    out[path.basename(name, docExt)] = fs.readFileSync(local(name), 'utf8') + '\n\n';
+    return out;
+  }, {});
+
+console.log('Assembling README and CLI help...');
+var readme = docs.intro + docs.usage + docs.installation + docs.license;
+var printUsage = docs.usage + '\n' + docs.license;
+var cliSource = fs.readFileSync(local('cli-template.js'), 'utf8');
+
+console.log('Writing README...');
+fs.writeFileSync(up('README.md'), readme, 'utf8');
+console.log('Writing CLI help...');
+fs.writeFileSync(
+    up('cli.js'),
+    cliSource.replace(/__USAGE__/, JSON.stringify(printUsage))
+);
+console.log('Done.');

--- a/meta/usage.md
+++ b/meta/usage.md
@@ -1,37 +1,3 @@
-# gnomon
-
-A command line utility, a bit like
-[moreutils's **ts**](https://joeyh.name/code/moreutils/), to prepend timestamp
-information to the standard output of another command. Useful for long-running
-processes where you'd like a historical record of what's taking so long.
-
-## Example
-
-![basic](https://cloud.githubusercontent.com/assets/1643758/13685018/17b4f76c-e6d4-11e5-8838-40fa52346ae8.gif)
-
-Piping anything to `gnomon` will prepend a timestamp to each line, indicating 
-how long that line was the last line in the buffer--that is, how long it took
-the next line to appear. By default, `gnomon` will display the seconds elapsed
-between each line, but that is configurable.
-
-You can display total time elapsed since the process began:
-![total](https://cloud.githubusercontent.com/assets/1643758/13685020/199b78b2-e6d4-11e5-9083-05de6c52cc60.gif)
-
-You can display an absolute timestamp:
-![absolute](https://cloud.githubusercontent.com/assets/1643758/13685022/1ab3a5bc-e6d4-11e5-9ccf-3a5c68f9ea0c.gif)
-
-You can also use the `--high` and/or `--medium` options to specify a length
-threshold in seconds, over which `gnomon` will highlight the timestamp in red
-or yellow. And you can do a few other things, too.
-
-![fancy](https://cloud.githubusercontent.com/assets/1643758/13685025/1bbf6ad6-e6d4-11e5-8806-e90a6e852bf7.gif)
-
-If the realtime timestamp updating is distracting or incompatible with your
-terminal, it can be disabled:
-
-![norealtime](https://cloud.githubusercontent.com/assets/1643758/13685027/1cfd823e-e6d4-11e5-9f90-c047d67a35e0.gif)
-
-
 ## Options
 
     --type=<elapsed-line|elapsed-total|absolute>        [default: elapsed-line]
@@ -93,15 +59,3 @@ meeting that threshold will be colored bright green.
  `--real-time=<ms>` argument explicitly, but the ANSI codes would probably
  interfere with whatever you were trying to do. The sane default is to omit fancy
  stuff, like colors and escape sequences, when logging text directly to a file.
-
-## Installation
-
-with npm do:
-```
-npm install -g gnomon
-```
-
-## License
-
-gnomon uses the MIT license.
-

--- a/package.json
+++ b/package.json
@@ -6,8 +6,10 @@
   "bin": {
     "gnomon": "./bin/gnomon"
   },
+  "man": "./doc/gnomon.1",
   "scripts": {
-    "test": "node test/timer.js | ./bin/gnomon | node test/validator.js"
+    "test": "node test/timer.js | ./bin/gnomon | node test/validator.js",
+    "docs": "node meta/make-docs.js && marked-man README.md > ./doc/gnomon.1"
   },
   "repository": {
     "type": "git",
@@ -33,10 +35,13 @@
   "dependencies": {
     "chalk": "^1.1.1",
     "dateutil": "^0.1.0",
-    "minimist": "^1.2.0",
+    "meow": "^3.7.0",
     "repeating": "^2.0.0",
     "split": "^1.0.0",
     "through": "^2.3.8",
     "window-size": "^0.2.0"
+  },
+  "devDependencies": {
+    "marked-man": "^0.1.6"
   }
 }


### PR DESCRIPTION
 - made `./meta` dir for build tasks
 - broke docs into subject matter area
 - made `./meta/make-docs.js` script for making README and cli help
 - replaced `minimist` with [meow](/sindresorhus/meow) for richer CLI and help prompt
 - added manpage